### PR TITLE
fix import path to gorilla mux

### DIFF
--- a/server.go
+++ b/server.go
@@ -12,7 +12,7 @@ import (
 	"os"
 	"strings"
 
-	"code.google.com/p/gorilla/mux"
+	"github.com/gorilla/mux"
 	"github.com/golang/glog"
 )
 


### PR DESCRIPTION
Hi,
Google Code is closing, so goexpose should replace the import path.

```
go get -v github.com/phonkee/goexpose/...
github.com/phonkee/goexpose (download)
package github.com/phonkee/goexpose
        imports code.google.com/p/gorilla/mux: unable to detect version control system for code.google.com/ path
```

Cheers, Enrico
